### PR TITLE
Add notes for SC 1.4.12

### DIFF
--- a/wcag.json
+++ b/wcag.json
@@ -790,7 +790,14 @@
                                 "title": "Exception: Human languages and scripts that do not make use of one or more of these text style properties in written text can conform using only the properties that exist for that combination of language and script."
                             }
                         ],
-                        "notes": null,
+                        "notes": [
+                            {
+                                "content": "Content is not required to use these text spacing values. The requirement is to ensure that when a user overrides the authored text spacing, content or functionality is not lost."
+                            },
+                            {
+                                "content": "Writing systems for some languages use different text spacing settings, such as paragraph start indent. Authors are encouraged to follow locally available guidance for improving readability and legibility of text in their writing system."
+                            }
+                        ],
                         "references": [
                             {
                                 "title": "How to Meet 1.4.12",


### PR DESCRIPTION
Adds two notes from the current WCAG document to SC 1.4.12: Text Spacing

> NOTE 1
Content is not required to use these text spacing values. The requirement is to ensure that when a user overrides the authored text spacing, content or functionality is not lost.

> NOTE 2
Writing systems for some languages use different text spacing settings, such as paragraph start indent. Authors are encouraged to follow locally available guidance for improving readability and legibility of text in their writing system.